### PR TITLE
Fixes bug in BTYD dataset generation

### DIFF
--- a/neural_lifetimes/data/datasets/btyd.py
+++ b/neural_lifetimes/data/datasets/btyd.py
@@ -486,14 +486,15 @@ class BTYD(SequenceDataset):
         discrete_funcs = {}
         discrete_feat_values = self.get_discrete_feature_values()
         for k, v in discrete_feat_values.items():
-            discrete_funcs[k] = lambda input_: self._feature_select_discrete(input_[0], input_[1], v, k)
+            discrete_funcs[k] = lambda input_, v=v, k=k: self._feature_select_discrete(input_[0], input_[1], v, k)
 
         # get continuous values
         continuous_features = self.continuous_feature_names
         cont_funcs = {}
         for feature in continuous_features:
-            cont_funcs[feature] = lambda input_: self._feature_select_cont(input_[0], input_[1], feature)
-
+            cont_funcs[feature] = lambda input_, feature=feature: self._feature_select_cont(
+                input_[0], input_[1], feature
+            )
         # user id
         special_feat = {"USER_PROFILE_ID": lambda input_: np.full(shape=input_[0], fill_value=str(uuid4()))}
 

--- a/neural_lifetimes/models/nets/event_model.py
+++ b/neural_lifetimes/models/nets/event_model.py
@@ -9,14 +9,14 @@ from .embedder import CombinedEmbedder
 
 # TODO rename
 class EventEncoder(nn.Module):
-    def __init__(
-        self,
-        emb: CombinedEmbedder,
-        rnn_dim: int,
-        drop_rate: float = 0.0,
-    ):
+    def __init__(self, emb: CombinedEmbedder, rnn_dim: int, drop_rate: float = 0.0, num_layers: int = 1):
         super().__init__()
         self.emb = emb
+
+        if num_layers == 1:
+            drop_rate = 0.0
+            print("Dropout for RNN was set to 0, because num_layers=1.")
+
         self.rnn = nn.GRU(
             input_size=emb.output_shape[1],
             hidden_size=rnn_dim,

--- a/neural_lifetimes/run_model.py
+++ b/neural_lifetimes/run_model.py
@@ -89,7 +89,7 @@ def run_model(
     callbacks = [
         ModelCheckpoint(
             dirpath=os.path.join(log_dir, f"version_{loggers[0].version}"),
-            filename="{epoch}-{step}-{loss_total_val:.2f}",
+            filename="{epoch}-{step}-{val_loss/total:.2f}",
             monitor="val_loss/total",
             mode="min",
             save_last=True,


### PR DESCRIPTION
## Problem

The simulation of features in the BTYD dataset is done by lambda functions. The closure is set by reference in a loop leading to incorrect feature simulation.

## Proposed changes

- fix BTYD data generation.
- fix checkpoint naming (on the side)
- fix warning message when using non-zero dropout and 1 GRU layer (on the side)

## Types of changes

What types of changes does your code introduce to neural-lifetimes?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
