### PR TITLE
Introduce Clickhouse Dataset debug mode - and Bug fixes 

### DIFF
--- a/examples/eventsprofiles_btyd.py
+++ b/examples/eventsprofiles_btyd.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
         start_token_discrete=START_TOKEN_DISCR,
         start_token_other=np.nan,
         max_item_len=100,
+        start_token_timestamp=datetime.datetime(1970, 1, 1, 1, 0),
     )
 
     target_transform = TargetCreator(cols=COLS)

--- a/neural_lifetimes/utils/callbacks/distribution_monitor.py
+++ b/neural_lifetimes/utils/callbacks/distribution_monitor.py
@@ -172,7 +172,9 @@ class DistributionMonitor(pl.Callback):
 
         # TODO better ways to approximate KL empirically:
         # https://www.semanticscholar.org/paper/Kullback-Leibler-divergence-estimation-of-P%C3%A9rez-Cruz/310974d3c141589a7800d737e5859b76676dcb5d?p2df
-        metrics = self.metrics.compute()
-        pl_module.log_dict({f"time_intervals/{k}": v for k, v in metrics.items()}, batch_size=len(y_pred))
-
+        try:
+            metrics = self.metrics.compute()
+            pl_module.log_dict({f"time_intervals/{k}": v for k, v in metrics.items()}, batch_size=len(y_pred))
+        except:  # noqa
+            print("Distribution Monitor: Metrics could not be computed.")
         self.metrics.reset()

--- a/neural_lifetimes/utils/callbacks/git.py
+++ b/neural_lifetimes/utils/callbacks/git.py
@@ -19,8 +19,8 @@ class GitInformationLogger(pl.Callback):
         self.verbose = verbose
 
         # check whether run started in git repo:
-        out = subprocess.run(["git", "status", "-s"], stdout=subprocess.PIPE)
-        if out.stdout.startswith(b"fatal: not a git repository"):
+        out = subprocess.run(["git", "status", "-s"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        if out.stderr.startswith(b"fatal: not a git repository"):
             raise SystemError(
                 "The entrypoint for the script is not inside a git repository. Consider running `git init` "
                 + f"in you shell or remove the {self.__class__.__name__} callback."

--- a/neural_lifetimes/utils/data/tokenizer.py
+++ b/neural_lifetimes/utils/data/tokenizer.py
@@ -59,7 +59,7 @@ class Tokenizer:
 
         # add start tokens
         for k, v in x.items():
-            if k in self.features:
+            if k in self.features or k in ["t", "dt"]:
                 if k in self.discrete_features:
                     x[k] = np.append([self.start_token_discrete], v)
                 else:

--- a/neural_lifetimes/utils/data/tokenizer.py
+++ b/neural_lifetimes/utils/data/tokenizer.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List, Dict
 
 from dataclasses import dataclass
@@ -18,8 +19,9 @@ class Tokenizer:
             The tokenizer performs left-truncation. The length of returned sequences will be ``max_item_len + 1``.
         start_token_continuous (np.float32): The start token for variables specified in ``continuous_features``.
         start_token_discrete (str): The start token for variables specified in ``discrete_features``.
-        start_token_other (np.float32): The start token for variables not specified in ``continuous_features``
-            or `discrete_features``.
+        start_token_timestamp (datetime.datetime): The start token for variables with data type ``np.datetime64``.
+        start_token_other (np.float32): The start token for variables not specified in ``continuous_features``,
+            `discrete_features`` or of type ``np.datetime64``.
 
     Attributes:
         continuous_features (List[str]): A list containing the names of the continuous features.
@@ -29,8 +31,9 @@ class Tokenizer:
             The tokenizer performs left-truncation. The length of returned sequences will be ``max_item_len + 1``.
         start_token_continuous (np.float32): The start token for variables specified in ``continuous_features``.
         start_token_discrete (str): The start token for variables specified in ``discrete_features``.
-        start_token_other (np.float32): The start token for variables not specified in ``continuous_features``
-            or `discrete_features``.
+        start_token_timestamp (datetime.datetime): The start token for variables with data type ``np.datetime64``.
+        start_token_other (np.float32): The start token for variables not specified in ``continuous_features``,
+            `discrete_features`` or of type ``np.datetime64``.
     """
 
     continuous_features: List[str]
@@ -38,6 +41,7 @@ class Tokenizer:
     max_item_len: int
     start_token_continuous: np.float32
     start_token_discrete: str
+    start_token_timestamp: datetime
     start_token_other: np.float32
 
     def __call__(self, x: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
@@ -60,7 +64,10 @@ class Tokenizer:
                 else:
                     x[k] = np.append([self.start_token_continuous], v)
             else:
-                x[k] = np.append([self.start_token_other], v)
+                if v.dtype == np.datetime64:
+                    x[k] = np.append(np.array([self.start_token_timestamp], dtype=np.datetime64), v)
+                else:
+                    x[k] = np.append([self.start_token_other], v)
         return x
 
     @property

--- a/neural_lifetimes/utils/data/tokenizer.py
+++ b/neural_lifetimes/utils/data/tokenizer.py
@@ -31,7 +31,8 @@ class Tokenizer:
             The tokenizer performs left-truncation. The length of returned sequences will be ``max_item_len + 1``.
         start_token_continuous (np.float32): The start token for variables specified in ``continuous_features``.
         start_token_discrete (str): The start token for variables specified in ``discrete_features``.
-        start_token_timestamp (datetime.datetime): The start token for variables with data type ``np.datetime64``.
+        start_token_timestamp (datetime.datetime): The start token for variables with numpy dtype of kind ``datetime``,
+            i.e. ``dtype.kind == 'M'``.
         start_token_other (np.float32): The start token for variables not specified in ``continuous_features``,
             `discrete_features`` or of type ``np.datetime64``.
     """
@@ -64,7 +65,8 @@ class Tokenizer:
                 else:
                     x[k] = np.append([self.start_token_continuous], v)
             else:
-                if v.dtype == np.datetime64:
+                # numpy dtype kind "M" is any datetime object
+                if v.dtype.kind == "M":
                     x[k] = np.append(np.array([self.start_token_timestamp], dtype=np.datetime64), v)
                 else:
                     x[k] = np.append([self.start_token_other], v)

--- a/tests/test_interface/test_run_model.py
+++ b/tests/test_interface/test_run_model.py
@@ -51,7 +51,9 @@ def data_and_model() -> Tuple[SequenceDataModule, ClassicModel]:
 
     transform = FeatureDictionaryEncoder(data_model.cont_feat, discr_values)
     target_transform = TargetCreator(cols=data_model.target_cols + data_model.cont_feat + data_model.discr_feat)
-    tokenizer = Tokenizer(data_model.cont_feat, discr_values, 100, np.nan, "<StartToken>", np.nan)
+    tokenizer = Tokenizer(
+        data_model.cont_feat, discr_values, 100, np.nan, "<StartToken>", datetime.datetime(1970, 1, 1), np.nan
+    )
 
     datamodule = SequenceDataModule(
         dataset=dataset,

--- a/tests/test_modules/test_classic_model.py
+++ b/tests/test_modules/test_classic_model.py
@@ -49,11 +49,18 @@ class TestClassicModel:
 
         discr_values = dataset.get_discrete_feature_values("<StartToken>")
 
-        tokenizer = Tokenizer(data_model.cont_feat, discr_values, 100, np.nan, "<StartToken>", np.nan)
+        tokenizer = Tokenizer(
+            data_model.cont_feat,
+            discr_values,
+            100,
+            np.nan,
+            "<StartToken>",
+            datetime.datetime(1970, 1, 1, 0, 0, 0),
+            np.nan,
+        )
         transform = FeatureDictionaryEncoder(data_model.cont_feat, discr_values)
 
         target_transform = TargetCreator(cols=(data_model.target_cols + data_model.cont_feat + data_model.discr_feat))
-
         datamodule = SequenceDataModule(
             dataset=dataset,
             tokenizer=tokenizer,

--- a/tests/test_utils/test_data/test_tokenizer.py
+++ b/tests/test_utils/test_data/test_tokenizer.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Dict
 import numpy as np
 
@@ -14,6 +15,10 @@ def data():
         "Other_CF": np.array([0, 1, 0, 1]),
         "DF1": np.array(["level_1", "level_1", "level_2", "level_3"]),
         "Other_DF": np.array(["level_1", "level_1", "level_2", "level_3"]),
+        "dates": np.array(
+            [datetime(2022, 1, 1), datetime(2022, 2, 1), datetime(2022, 3, 1), datetime(2022, 1, 1)],
+            dtype=np.datetime64,
+        ),
     }
 
 
@@ -26,6 +31,7 @@ def tokenizer():
         start_token_continuous=float("inf"),
         start_token_discrete="BigBang",
         start_token_other=-1,
+        start_token_timestamp=datetime(1970, 1, 1, 0, 0, 0, 0),
     )
 
 
@@ -42,6 +48,10 @@ def test_call(data: Dict[str, np.ndarray], tokenizer: Tokenizer):
         "Other_CF": np.array([-1, 0, 1]),
         "DF1": np.array(["BigBang", "level_2", "level_3"]),
         "Other_DF": np.array([-1, "level_2", "level_3"]),
+        "dates": np.array(
+            [datetime(1970, 1, 1, 0, 0, 0, 0), datetime(2022, 3, 1), datetime(2022, 1, 1)],
+            dtype=np.datetime64,
+        ),
     }
 
     for k in tokenized.keys():


### PR DESCRIPTION
## Problem

Loading the Clickhouse Indices can be very slow - too slow for debugging.

## Proposed changes

* A new `limit` argument is introduced to to limit the number of indices in the database to be queried.
* BUGFIX in Distribution monitor, for an issue in computing metrics when the validation set becomes too small
*  The Tokenizer has a new attribute `start_token_datetime`, which encodes datetime objects specifically with this token.

## Types of changes

What types of changes does your code introduce to neural-lifetimes?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
