### PR TITLE
Enabling Data Loading for forecasting data

### DIFF
--- a/neural_lifetimes/data/datasets/clickhouse_sequence.py
+++ b/neural_lifetimes/data/datasets/clickhouse_sequence.py
@@ -18,10 +18,38 @@ class ClickhouseSequenceDataset(SequenceDataset):
         table_name: str,
         uid_name: str,
         time_col: str,
-        asof_time: datetime.datetime,  # return no records after this
+        asof_time: datetime.datetime,
+        last_event_time: Optional[datetime.datetime] = None,
         min_items_per_uid: int = 1,
         limit: Optional[int] = None,
     ):
+        """The ClickhouseSequenceDataset creates a SequenceDataset from a Clickhouse Database.
+
+        TODO: Add more detailed summary
+        Add picture of time sequences and splits.
+
+        Args:
+            host (str): Database host.
+            port (int): Database port.
+            http_port (int): HTTP port.
+            database (str): Database name.
+            table_name (str): Table name.
+            uid_name (str): Name of column containing user IDs.
+            time_col (str): Name of column containing timestamps of events.
+            asof_time (datetime.datetime): The assumed "present time". This will serve as a reference to the present
+                in loss functions. Further, it is used as cut-off to count training samples. This should be thought of
+                as the last date of the training time window.
+            last_event_time (Optional[datetime.datetime], optional): The cut-off date of events to be included in
+                batches. When this value is ``None`` the ``asof_time`` is used. To retreive data points in the training
+                time window, this should be ``None``. To retrieve data from training and forecasting time window, this
+                should be set to the last day of the forecasting window. Defaults to None.
+            min_items_per_uid (int, optional): The number of events before ``asof_time`` a customer should have to be
+                included in the dataset. Defaults to 1.
+            limit (Optional[int], optional): Limits the number of samples to be queried from the database.
+                This is particularly useful for debugging. This translates to a ``LIMIT`` instruction in the SQL query
+                and hence should not be used for generating simple random samples from database. If set to ``None``,
+                no limit is imposed. Defaults to None.
+        """
         self.host = host
         self.port = port
         self.http_port = http_port
@@ -31,23 +59,28 @@ class ClickhouseSequenceDataset(SequenceDataset):
         self.uid_name = uid_name
         self.time_col = time_col
         self.asof_time = asof_time
+        self.last_event_time = asof_time if last_event_time is None else last_event_time
+        assert self.last_event_time >= self.asof_time, "The 'last_event_time' is the last date in the "
         self.limit = limit
 
         # get all the UIDs with at least min_items_per_uid events
-        date_filt = self.asof_filter.replace("and", "where") if self.asof_filter else ""
+        date_filter = self.last_event_filter.replace("and", "where") if self.last_event_filter else ""
 
-        uid_query = f"""SELECT * from (
-        SELECT {uid_name},
-            count(*) as cnt,
-            min({time_col}) as first_t,
-            min({time_col}) as last_t
-        from {database}.{table_name}
-        {date_filt}
-        group by {uid_name}
-        order by {uid_name}
-        ) as tmp
-        where cnt >={min_items_per_uid}
-        """
+        uid_query = f"""
+                        SELECT {uid_name}, cnt
+                        FROM (
+                            SELECT {uid_name},
+                                count(*) as cnt,
+                                SUM(CASE WHEN {self.asof_filter.replace("and", "")} THEN 1 ELSE 0 END) AS cnt_asof
+                                --min({time_col}) as first_t,
+                                --min({time_col}) as last_t
+                            FROM {database}.{table_name}
+                            {date_filter}
+                            GROUP by {uid_name}
+                            order by {uid_name}
+                            ) AS tmp
+                        WHERE cnt_asof >={min_items_per_uid}
+                        """
         if self.limit:
             uid_query += f" LIMIT {self.limit}"
 
@@ -73,9 +106,20 @@ class ClickhouseSequenceDataset(SequenceDataset):
         self.__dict__.update(state)
         self.conn = Client(self.host)
 
+    def _time_filter(self, time_limit):
+        return (
+            ""
+            if getattr(self, time_limit) is None
+            else f" and {self.time_col} < toDateTime64('{getattr(self, time_limit)}',3)"
+        )
+
     @property
     def asof_filter(self):
-        return "" if self.asof_time is None else f" and {self.time_col} < toDateTime64('{self.asof_time}',3)"
+        return self._time_filter("asof_time")
+
+    @property
+    def last_event_filter(self):
+        return self._time_filter("last_event_time")
 
     def uids_filter(self, new_uids):
         if isinstance(new_uids, list):
@@ -101,7 +145,7 @@ class ClickhouseSequenceDataset(SequenceDataset):
         query = f"""
             SELECT * from {self.database}.{self.table_name}
             where {self.uid_name} in ({','.join(uids.astype(str))})
-            {self.asof_filter}
+            {self.last_event_filter}
             order by {self.uid_name}, {self.time_col}
         """
         raw_data = self.conn.execute(query)

--- a/neural_lifetimes/utils/__init__.py
+++ b/neural_lifetimes/utils/__init__.py
@@ -1,0 +1,3 @@
+from .date_arithmetic import datetime2float, float2datetime
+
+__all__ = [datetime2float, float2datetime]

--- a/neural_lifetimes/utils/date_arithmetic.py
+++ b/neural_lifetimes/utils/date_arithmetic.py
@@ -1,4 +1,6 @@
 import datetime
+from typing import Union
+import numpy as np
 
 
 def date2time(date: datetime.date) -> datetime.datetime:
@@ -12,3 +14,70 @@ def date2time(date: datetime.date) -> datetime.datetime:
         datetime.datetime: The converted date.
     """
     return datetime.datetime.combine(date, datetime.datetime.min.time())
+
+
+DatetimeLike = Union[np.array, datetime.datetime]
+TimestampLike = Union[np.array, float, int]
+
+_conversion_factors = {
+    "d": 1e6 * 60 * 60 * 24,
+    "h": 1e6 * 60 * 60,
+    "min": 1e6 * 60,
+    "s": 1e6,
+    "ms": 1000,
+}
+
+
+def datetime2float(t: DatetimeLike, unit: str = "h") -> TimestampLike:
+    """Converts datetime-like objects to timestamps given a certain unit.
+
+    Args:
+        t (DatetimeLike): The datetime-like object, e.g. datetime.datetime or np.array["datetime64[us]"]
+        unit (str, optional): Units for the time scale. supported are "d", "h", "min", "s", "ms". Defaults to "h".
+
+    Raises:
+        ValueError: When "unit" not supported.
+        TypeError: when type of "t" not supported.
+
+    Returns:
+        TimestampLike: float or np.array[np.float32] with timestamps.
+    """
+    if unit not in _conversion_factors:
+        raise ValueError(f"Unit parameter '{unit}' not supported.")
+    if isinstance(t, datetime.datetime):
+        t = t.timestamp() * 1e6
+    elif isinstance(t, np.ndarray):
+        t = t.astype("datetime64[us]").astype(np.int64).astype(np.float32)
+    else:
+        raise TypeError(f"Datetime must be of type 'DatetimeLike'. Got '{type(t).__name__}'")
+    # time is in microseconds
+    t = t / _conversion_factors[unit]
+    # time is in hours
+    return t
+
+
+def float2datetime(t: TimestampLike, unit: str = "h") -> DatetimeLike:
+    """Converts float values to datetime objects.
+
+    Args:
+        t (TimestampLike): numeric value with timestamp.
+        unit (str, optional): Units for the time scale. supported are "d", "h", "min", "s", "ms". Defaults to "h".
+
+    Raises:
+        ValueError: When "unit" not supported.
+        TypeError: when type of "t" not supported.
+
+    Returns:
+        DatetimeLike: The datetimes.
+    """
+    if unit not in _conversion_factors:
+        raise ValueError(f"Unit parameter '{unit}' not supported.")
+    t = t * _conversion_factors[unit]
+    if isinstance(t, (float, int)):
+        t = datetime.datetime.fromtimestamp(t / 1e6)
+    elif isinstance(t, np.ndarray):
+        t = t.astype("datetime64[us]")
+    else:
+        raise TypeError(f"Datetime must be of type 'TimestampLike'. Got '{type(t).__name__}'")
+
+    return t

--- a/tests/test_utils/test_date_arithmetic.py
+++ b/tests/test_utils/test_date_arithmetic.py
@@ -1,0 +1,103 @@
+from datetime import datetime, timedelta
+
+import numpy as np
+
+import pytest
+from neural_lifetimes.utils import datetime2float, float2datetime
+from neural_lifetimes.utils.date_arithmetic import _conversion_factors
+
+
+@pytest.fixture
+def datetimes():
+    return [datetime(2000 + i, i, 2 * i) for i in range(1, 13)]
+
+
+@pytest.fixture
+def timestamps():
+    return [
+        271776.0,
+        281328.0,
+        290808.0,
+        300383.0,
+        309911.0,
+        319463.0,
+        328991.0,
+        338567.0,
+        348119.0,
+        357647.0,
+        367200.0,
+        376752.0,
+    ]
+
+
+# tolerance in hours
+@pytest.fixture
+def error_tolerance():
+    return 2
+
+
+class Test_Base:
+    @staticmethod
+    def test_datetime2float(datetimes, timestamps, error_tolerance):
+        res = [datetime2float(dt) for dt in datetimes]
+        assert all([(r - t) < error_tolerance for r, t in zip(res, timestamps)])
+
+    @staticmethod
+    def test_float2datetime(datetimes, timestamps, error_tolerance):
+        res = [float2datetime(ts) for ts in timestamps]
+        assert all([(r - t) < timedelta(hours=error_tolerance) for r, t in zip(res, datetimes)])
+
+    @staticmethod
+    def test_both(datetimes, error_tolerance):
+        res = [float2datetime(datetime2float(dt)) for dt in datetimes]
+        assert all([(r - t) < timedelta(hours=error_tolerance) for r, t in zip(res, datetimes)])
+
+
+class Test_Numpy:
+    @staticmethod
+    def test_datetime2float(datetimes, timestamps, error_tolerance):
+        datetimes = np.array(datetimes, dtype="datetime64[us]")
+        timestamps = np.array(timestamps)
+        res = datetime2float(datetimes)
+        assert np.all(np.isclose(res, timestamps, rtol=0, atol=error_tolerance))
+
+    @staticmethod
+    def test_float2datetime(datetimes, timestamps, error_tolerance):
+        datetimes = np.array(datetimes, dtype="datetime64[us]")
+        timestamps = np.array(timestamps)
+        res = float2datetime(timestamps)
+        assert np.all((res - datetimes) < timedelta(hours=error_tolerance))
+
+    @staticmethod
+    def test_both(datetimes, timestamps, error_tolerance):
+        datetimes = np.array(datetimes, dtype="datetime64[us]")
+        timestamps = np.array(timestamps)
+        res = float2datetime(datetime2float(datetimes))
+        assert np.all((res - datetimes) < timedelta(hours=error_tolerance))
+
+
+class Test_AcrossTypes:
+    @staticmethod
+    def test_numpy_base(datetimes, error_tolerance):
+        res_base = np.array([datetime2float(dt) for dt in datetimes])
+        np_datetimes = np.array(datetimes, dtype="datetime64[us]")
+        res_np = datetime2float(np_datetimes)
+        assert np.all(np.isclose(res_base, res_np, rtol=0, atol=error_tolerance))
+
+
+class Test_Units:
+    @staticmethod
+    def test_tofloat(datetimes, error_tolerance):
+        cf = _conversion_factors
+        base = np.array([datetime2float(dt) for dt in datetimes])
+        res = {unit: np.array([datetime2float(dt, unit=unit) for dt in datetimes]) for unit in cf.keys()}
+        for unit, arr in res.items():
+            assert np.all(np.isclose(arr * cf[unit] / cf["h"], base, rtol=0, atol=error_tolerance))
+
+    @staticmethod
+    def test_todatetime(datetimes, timestamps, error_tolerance):
+        cf = _conversion_factors
+        timestamps = {unit: [ts / cf[unit] * cf["h"] for ts in timestamps] for unit in cf.keys()}
+        res = {unit: [float2datetime(ts, unit=unit) for ts in tstamp] for unit, tstamp in timestamps.items()}
+        for arr in res.values():
+            assert all([(r - t) < timedelta(hours=error_tolerance) for r, t in zip(arr, datetimes)])


### PR DESCRIPTION

## Problem

When forecasting during training we wish to compare to true data. Hence, we need to query data from past the `asof_date`. This requires changes in the data pipeline.

## Proposed changes

* The workflow now requires to create 2 datasets: one for the training time window and a second dataset for the training and forecasting time windows. 
* Clickhouse Sequence Loader can now output data in the training time window and forecasting data. The `last_event_time` now acts as the last time for events in batches and `asof_time` is now the reference value for the end of the training window.

* The SequenceDataModule can now create forecasting dataloaders using methods `{split}_forecast_loader()` based of the `forecast_dataset` passed in as argument. The `predict_dataloader` is  now also based on the `forecast_dataset`.


## Types of changes

What types of changes does your code introduce to neural-lifetimes?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
