### PR TITLE
Unified Datetime to Timestamp conversions and back

### DIFF
--- a/neural_lifetimes/utils/__init__.py
+++ b/neural_lifetimes/utils/__init__.py
@@ -1,0 +1,3 @@
+from .date_arithmetic import datetime2float, float2datetime
+
+__all__ = [datetime2float, float2datetime]

--- a/neural_lifetimes/utils/date_arithmetic.py
+++ b/neural_lifetimes/utils/date_arithmetic.py
@@ -27,10 +27,21 @@ _conversion_factors = {
     "ms": 1000,
 }
 
-# TODO: Implement lists, test different timescales, implement torch
-
 
 def datetime2float(t: DatetimeLike, unit: str = "h") -> TimestampLike:
+    """Converts datetime-like objects to timestamps given a certain unit.
+
+    Args:
+        t (DatetimeLike): The datetime-like object, e.g. datetime.datetime or np.array["datetime64[us]"]
+        unit (str, optional): Units for the time scale. supported are "d", "h", "min", "s", "ms". Defaults to "h".
+
+    Raises:
+        ValueError: When "unit" not supported.
+        TypeError: when type of "t" not supported.
+
+    Returns:
+        TimestampLike: float or np.array[np.float32] with timestamps.
+    """
     if unit not in _conversion_factors:
         raise ValueError(f"Unit parameter '{unit}' not supported.")
     if isinstance(t, datetime.datetime):
@@ -45,7 +56,20 @@ def datetime2float(t: DatetimeLike, unit: str = "h") -> TimestampLike:
     return t
 
 
-def float2datetime(t: TimestampLike, unit: str = "h"):
+def float2datetime(t: TimestampLike, unit: str = "h") -> DatetimeLike:
+    """Converts float values to datetime objects.
+
+    Args:
+        t (TimestampLike): numeric value with timestamp.
+        unit (str, optional): Units for the time scale. supported are "d", "h", "min", "s", "ms". Defaults to "h".
+
+    Raises:
+        ValueError: When "unit" not supported.
+        TypeError: when type of "t" not supported.
+
+    Returns:
+        DatetimeLike: The datetimes.
+    """
     if unit not in _conversion_factors:
         raise ValueError(f"Unit parameter '{unit}' not supported.")
     t = t * _conversion_factors[unit]
@@ -54,6 +78,6 @@ def float2datetime(t: TimestampLike, unit: str = "h"):
     elif isinstance(t, np.ndarray):
         t = t.astype("datetime64[us]")
     else:
-        raise TypeError(f"Datetime must be of type 'DatetimeLike'. Got '{type(t).__name__}'")
+        raise TypeError(f"Datetime must be of type 'TimestampLike'. Got '{type(t).__name__}'")
 
     return t

--- a/neural_lifetimes/utils/date_arithmetic.py
+++ b/neural_lifetimes/utils/date_arithmetic.py
@@ -1,7 +1,6 @@
 import datetime
 from typing import Union
 import numpy as np
-import torch
 
 
 def date2time(date: datetime.date) -> datetime.datetime:
@@ -17,8 +16,8 @@ def date2time(date: datetime.date) -> datetime.datetime:
     return datetime.datetime.combine(date, datetime.datetime.min.time())
 
 
-DatetimeLike = Union[torch.tensor, np.array, datetime.datetime]
-TimestampLike = Union[torch.tensor, np.array, float, int]
+DatetimeLike = Union[np.array, datetime.datetime]
+TimestampLike = Union[np.array, float, int]
 
 _conversion_factors = {
     "d": 1e6 * 60 * 60 * 24,
@@ -38,8 +37,6 @@ def datetime2float(t: DatetimeLike, unit: str = "h") -> TimestampLike:
         t = t.timestamp() * 1e6
     elif isinstance(t, np.ndarray):
         t = t.astype("datetime64[us]").astype(np.int64).astype(np.float32)
-    elif isinstance(t, torch.tensor):
-        raise NotImplementedError
     else:
         raise TypeError(f"Datetime must be of type 'DatetimeLike'. Got '{type(t).__name__}'")
     # time is in microseconds
@@ -56,8 +53,6 @@ def float2datetime(t: TimestampLike, unit: str = "h"):
         t = datetime.datetime.fromtimestamp(t / 1e6)
     elif isinstance(t, np.ndarray):
         t = t.astype("datetime64[us]")
-    elif isinstance(t, torch.tensor):
-        raise NotImplementedError
     else:
         raise TypeError(f"Datetime must be of type 'DatetimeLike'. Got '{type(t).__name__}'")
 

--- a/neural_lifetimes/utils/date_arithmetic.py
+++ b/neural_lifetimes/utils/date_arithmetic.py
@@ -1,4 +1,7 @@
 import datetime
+from typing import Union
+import numpy as np
+import torch
 
 
 def date2time(date: datetime.date) -> datetime.datetime:
@@ -12,3 +15,36 @@ def date2time(date: datetime.date) -> datetime.datetime:
         datetime.datetime: The converted date.
     """
     return datetime.datetime.combine(date, datetime.datetime.min.time())
+
+
+DatetimeLike = Union[torch.tensor, np.array, datetime.datetime]
+TimestampLike = Union[torch.tensor, np.array, float, int]
+
+
+def datetime2float(t: DatetimeLike, unit: str = "h") -> TimestampLike:
+    if isinstance(t, datetime.datetime):
+        t = t.timestamp() * 1e6
+    elif isinstance(t, np.ndarray):
+        t = t.astype("datetime64[us]").astype(np.int64).astype(np.float32)
+    elif isinstance(t, torch.tensor):
+        raise NotImplementedError
+    else:
+        raise TypeError(f"Datetime must be of type 'DatetimeLike'. Got '{type(t).__name__}'")
+    # time is in microseconds
+    t = t / (1e6 * 60 * 60)
+    # time is in hours
+    return t
+
+
+def float2datetime(t: TimestampLike, unit: str = "h"):
+    t = t * (1e6 * 60 * 60)
+    if isinstance(t, (float, int)):
+        t = datetime.datetime.fromtimestamp(t / 1e6)
+    elif isinstance(t, np.ndarray):
+        t = t.astype("datetime64[us]")
+    elif isinstance(t, torch.tensor):
+        raise NotImplementedError
+    else:
+        raise TypeError(f"Datetime must be of type 'DatetimeLike'. Got '{type(t).__name__}'")
+
+    return t

--- a/neural_lifetimes/utils/date_arithmetic.py
+++ b/neural_lifetimes/utils/date_arithmetic.py
@@ -20,8 +20,20 @@ def date2time(date: datetime.date) -> datetime.datetime:
 DatetimeLike = Union[torch.tensor, np.array, datetime.datetime]
 TimestampLike = Union[torch.tensor, np.array, float, int]
 
+_conversion_factors = {
+    "d": 1e6 * 60 * 60 * 24,
+    "h": 1e6 * 60 * 60,
+    "min": 1e6 * 60,
+    "s": 1e6,
+    "ms": 1000,
+}
+
+# TODO: Implement lists, test different timescales, implement torch
+
 
 def datetime2float(t: DatetimeLike, unit: str = "h") -> TimestampLike:
+    if unit not in _conversion_factors:
+        raise ValueError(f"Unit parameter '{unit}' not supported.")
     if isinstance(t, datetime.datetime):
         t = t.timestamp() * 1e6
     elif isinstance(t, np.ndarray):
@@ -31,13 +43,15 @@ def datetime2float(t: DatetimeLike, unit: str = "h") -> TimestampLike:
     else:
         raise TypeError(f"Datetime must be of type 'DatetimeLike'. Got '{type(t).__name__}'")
     # time is in microseconds
-    t = t / (1e6 * 60 * 60)
+    t = t / _conversion_factors[unit]
     # time is in hours
     return t
 
 
 def float2datetime(t: TimestampLike, unit: str = "h"):
-    t = t * (1e6 * 60 * 60)
+    if unit not in _conversion_factors:
+        raise ValueError(f"Unit parameter '{unit}' not supported.")
+    t = t * _conversion_factors[unit]
     if isinstance(t, (float, int)):
         t = datetime.datetime.fromtimestamp(t / 1e6)
     elif isinstance(t, np.ndarray):

--- a/tests/test_utils/test_date_arithmetic.py
+++ b/tests/test_utils/test_date_arithmetic.py
@@ -3,7 +3,8 @@ from datetime import datetime, timedelta
 import numpy as np
 
 import pytest
-from neural_lifetimes.utils.date_arithmetic import datetime2float, float2datetime, _conversion_factors
+from neural_lifetimes.utils import datetime2float, float2datetime
+from neural_lifetimes.utils.date_arithmetic import _conversion_factors
 
 
 @pytest.fixture

--- a/tests/test_utils/test_date_arithmetic.py
+++ b/tests/test_utils/test_date_arithmetic.py
@@ -78,9 +78,13 @@ class Test_Numpy:
 
 class Test_AcrossTypes:
     @staticmethod
-    def test_numpy_base():
-        assert False
+    def test_numpy_base(datetimes, error_tolerance):
+        res_base = np.array([datetime2float(dt) for dt in datetimes])
+        np_datetimes = np.array(datetimes, dtype="datetime64[us]")
+        res_np = datetime2float(np_datetimes)
+        assert np.all(np.isclose(res_base, res_np, rtol=0, atol=error_tolerance))
 
     @staticmethod
+    @pytest.mark.xfail
     def test_numpy_torch():
         assert False

--- a/tests/test_utils/test_date_arithmetic.py
+++ b/tests/test_utils/test_date_arithmetic.py
@@ -1,0 +1,86 @@
+from datetime import datetime, timedelta
+
+import numpy as np
+import torch
+
+import pytest
+from neural_lifetimes.utils.date_arithmetic import datetime2float, float2datetime
+
+
+@pytest.fixture
+def datetimes():
+    return [datetime(2000 + i, i, 2 * i) for i in range(1, 13)]
+
+
+@pytest.fixture
+def timestamps():
+    return [
+        271776.0,
+        281328.0,
+        290808.0,
+        300383.0,
+        309911.0,
+        319463.0,
+        328991.0,
+        338567.0,
+        348119.0,
+        357647.0,
+        367200.0,
+        376752.0,
+    ]
+
+
+# tolerance in hours
+@pytest.fixture
+def error_tolerance():
+    return 2
+
+
+class Test_Base:
+    @staticmethod
+    def test_datetime2float(datetimes, timestamps, error_tolerance):
+        res = [datetime2float(dt) for dt in datetimes]
+        assert all([(r - t) < error_tolerance for r, t in zip(res, timestamps)])
+
+    @staticmethod
+    def test_float2datetime(datetimes, timestamps, error_tolerance):
+        res = [float2datetime(ts) for ts in timestamps]
+        assert all([(r - t) < timedelta(hours=error_tolerance) for r, t in zip(res, datetimes)])
+
+    @staticmethod
+    def test_both(datetimes, error_tolerance):
+        res = [float2datetime(datetime2float(dt)) for dt in datetimes]
+        assert all([(r - t) < timedelta(hours=error_tolerance) for r, t in zip(res, datetimes)])
+
+
+class Test_Numpy:
+    @staticmethod
+    def test_datetime2float(datetimes, timestamps, error_tolerance):
+        datetimes = np.array(datetimes, dtype="datetime64[us]")
+        timestamps = np.array(timestamps)
+        res = datetime2float(datetimes)
+        assert np.all(np.isclose(res, timestamps, rtol=0, atol=error_tolerance))
+
+    @staticmethod
+    def test_float2datetime(datetimes, timestamps, error_tolerance):
+        datetimes = np.array(datetimes, dtype="datetime64[us]")
+        timestamps = np.array(timestamps)
+        res = float2datetime(timestamps)
+        assert np.all((res - datetimes) < timedelta(hours=error_tolerance))
+
+    @staticmethod
+    def test_both(datetimes, timestamps, error_tolerance):
+        datetimes = np.array(datetimes, dtype="datetime64[us]")
+        timestamps = np.array(timestamps)
+        res = float2datetime(datetime2float(datetimes))
+        assert np.all((res - datetimes) < timedelta(hours=error_tolerance))
+
+
+class Test_AcrossTypes:
+    @staticmethod
+    def test_numpy_base():
+        assert False
+
+    @staticmethod
+    def test_numpy_torch():
+        assert False


### PR DESCRIPTION
## Problem

Everywhere in the script we need to convert between datetime objects and timestamps (i.e. floats). The conversion between these two is currently done in multiple places, which is prone to errors.

## Proposed changes

`neural_lifetimes.utils` gets two new functions: `datetime2float` and `float2datetime`.  These convert datetimes to floats and back.

Property A:
These functions work equally for:
* np.ndarray
* scalar-valued base types

Property B:
The timescale of timestamps can be selected. Supported are `h`, `d`, `min`, `s`, `ms`.

Property C:
In the feature all internal conversions of time scale should be done through these functions.

## Types of changes

What types of changes does your code introduce to neural-lifetimes?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
