### PR TITLE
fix Wasserstein and KL

### DIFF
--- a/neural_lifetimes/metrics/kullback_leibler.py
+++ b/neural_lifetimes/metrics/kullback_leibler.py
@@ -9,7 +9,7 @@ import torchmetrics
 
 class KullbackLeiblerDivergence(torchmetrics.Metric):
     def __init__(self, compute_on_step: Optional[bool] = None, **kwargs: Dict[str, Any]) -> None:
-        super().__init__(compute_on_step, **kwargs)
+        super().__init__()
         self.add_state("preds", default=[], dist_reduce_fx="cat")
         self.add_state("target", default=[], dist_reduce_fx="cat")
 
@@ -33,7 +33,7 @@ class ParametricKullbackLeiblerDivergence(torchmetrics.Metric):
         compute_on_step: Optional[bool] = None,
         **kwargs: Dict[str, Any]
     ) -> None:
-        super().__init__(compute_on_step, **kwargs)
+        super().__init__()
         self.add_state("preds", default=[], dist_reduce_fx="cat")
         self.add_state("target", default=[], dist_reduce_fx="cat")
         self.distribution = distribution

--- a/neural_lifetimes/metrics/sinkhorn.py
+++ b/neural_lifetimes/metrics/sinkhorn.py
@@ -12,7 +12,7 @@ import torchmetrics
 
 class WassersteinMetric(torchmetrics.Metric):
     def __init__(self, compute_on_step: Optional[bool] = None, **kwargs: Dict[str, Any]) -> None:
-        super().__init__(compute_on_step, **kwargs)
+        super().__init__()
         # intiialise states
         self.add_state("preds", default=[], dist_reduce_fx="cat")
         self.add_state("target", default=[], dist_reduce_fx="cat")


### PR DESCRIPTION
## Problem

Our metrics based on the class torchmetrics.Metric are crashing on the initialisation 

## Proposed changes

Remove arguments when calling the super().__init__ for KL and Wasserstein metrics. the initialisation of the  torchmetrics.Metric class doesn't take arguments

## Types of changes

What types of changes does your code introduce to neural-lifetimes?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
